### PR TITLE
Add public route to retrieve participant count per section for a given project

### DIFF
--- a/app/controllers/participants_controller.ts
+++ b/app/controllers/participants_controller.ts
@@ -176,4 +176,32 @@ export default class ParticipantsController {
     await participant.delete()
     return response.send('Participant deleted from the project')
   }
+
+async getParticipantsCountBySection(ctx: HttpContext) {
+  const projectId = ctx.params.id;
+
+  // On construit la requête sur Participant
+  const baseQuery = Participant.query()
+    .where('project_id', projectId)
+    .andWhere('accepted', true)
+    .select('section_id')
+    .count('id as participants_count')
+    .groupBy('section_id')
+    .preload('section', (query) => {
+      query.select('id', 'name');
+    });
+
+  const counts = await baseQuery;
+
+  // On mappe le résultat pour ne garder que l'essentiel
+  const result = counts.map((item) => ({
+    section_id: item.section_id,
+    section_name: item.section ? item.section.name : null,
+    participants_count: Number(item.$extras.participants_count) || 0,
+  }));
+
+  return result;
+}
+
+
 }

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -32,6 +32,10 @@ const DefaultTemplatesController = () => import('#controllers/default_templates_
 
 router.group(() => {
   //open routes
+
+  router.get('/test-public-route', async () => {
+  return { ok: true }
+  })
   router.group(() => {
     router.get('/', async () => {
       return {
@@ -46,6 +50,8 @@ router.group(() => {
 
     router.get('/call_sheets/:id/:visitorId', [CallsheetsController, 'getOne'])
     router.get('/files/download/:id', [FilesController, 'download'])
+
+    router.get('/projects/:id/public/participants-count', [ParticipantsController, 'getParticipantsCountBySection'])
   })
 
   //protected routes


### PR DESCRIPTION
This PR introduces a new public route that allows retrieving the number of participants registered in each section of a given project.
Key points:

1. ✅ The route is accessible without authentication.
2. 🔐 It only returns non-sensitive data: an array of objects, each containing a section and the number of participants in that section.
3. 🛡️ No personal or sensitive participant information is exposed.

This route is required to support the frontend feature that displays availability status when a user selects a section during registration.