### PR TITLE
bug fix events order in attendance table (and project dashboard)

### DIFF
--- a/app/controllers/projects_controller.ts
+++ b/app/controllers/projects_controller.ts
@@ -358,13 +358,17 @@ export default class ProjectsController {
     const project = await Project.query()
       .where('id', ctx.params.id)
       .preload('rehearsals', (query) => {
-        query.preload('participants', (participantQuery) => {
-          participantQuery.pivotColumns(['comment'])
+        query
+          .orderBy('start_date', 'asc')
+          .preload('participants', (participantQuery) => {
+            participantQuery.pivotColumns(['comment'])
         })
       })
       .preload('concerts', (query) => {
-        query.preload('participants', (participantQuery) => {
-          participantQuery.pivotColumns(['comment'])
+        query
+          .orderBy('start_date', 'asc')
+          .preload('participants', (participantQuery) => {
+            participantQuery.pivotColumns(['comment'])
         })
       })
       .preload('participants', (query) => {


### PR DESCRIPTION
added a line to projects_controller.ts to order rehearsal and concert dates chronologically when loading the events of a project