### PR TITLE
fix: use callsheet.id instead of project.id in notification email link

### DIFF
--- a/app/mails/callsheet_notification.ts
+++ b/app/mails/callsheet_notification.ts
@@ -89,7 +89,7 @@ export default class CallsheetNotification extends BaseMail {
       .replace(/\${PROJECT}/g, this.project.name)
       .replace(
         /\${CALLSHEET}/g,
-        url + '/call_sheets/' + this.project.id.toString() + '/' + this.contact.id.toString()
+        url + '/call_sheets/' + this.callsheet.id.toString() + '/' + this.contact.id.toString()
       )
       .replace(/\${TO_CONTACT}/g, toContactDetails)
 


### PR DESCRIPTION
Fixes #99

In callsheet_notification.ts, the email link sent to participants 
was built using project.id instead of callsheet.id, causing broken 
links in all callsheet notification emails.

Changed this.project.id to this.callsheet.id on line 92.