### PR TITLE
Worked on issue 102 fixing statuses bug

### DIFF
--- a/app/models/recruitment_contact.ts
+++ b/app/models/recruitment_contact.ts
@@ -5,15 +5,7 @@ import Project from './project.js'
 import Contact from './contact.js'
 import Section from './section.js'
 
-export type RecruitmentStatus =
-  | 'not_yet_contacted'
-  | 'awaiting_response'
-  | 'to_follow_up'
-  | 'not_available'
-  | 'pending_validation'
-  | 'cancelled'
-  | 'recruited'
-
+export type RecruitmentStatus = string
 export type ContactMethod = 'manual' | 'email' | 'messenger' | 'phone'
 
 export default class RecruitmentContact extends BaseModel {
@@ -45,7 +37,7 @@ export default class RecruitmentContact extends BaseModel {
   declare section_id: number | null
 
   @column()
-  declare status: RecruitmentStatus
+  declare status: string
 
   @column()
   declare contact_method: ContactMethod
@@ -211,10 +203,16 @@ export default class RecruitmentContact extends BaseModel {
       recruited: { label: 'Recruited', color: 'green', icon: 'CheckCircle' },
     }
 
-    return statusConfig[this.status] || statusConfig['not_yet_contacted']
+   return (
+  statusConfig[this.status as keyof typeof statusConfig] || {
+    label: this.status,
+    color: 'gray',
+    icon: 'Circle'
+  }
+)
   }
 
-  static getAvailableStatuses(): Array<{ value: RecruitmentStatus; label: string }> {
+  static getAvailableStatuses(): Array<{ value: string; label: string }> {
     return [
       { value: 'not_yet_contacted', label: 'Not yet contacted' },
       { value: 'awaiting_response', label: 'Awaiting response' },

--- a/database/migrations/1779374842232_create_remove_recruitment_status_constraints_table.ts
+++ b/database/migrations/1779374842232_create_remove_recruitment_status_constraints_table.ts
@@ -1,0 +1,28 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  async up() {
+    this.schema.raw(`
+      ALTER TABLE recruitment_contacts
+      DROP CONSTRAINT IF EXISTS recruitment_contacts_status_check
+    `)
+  }
+
+  async down() {
+    this.schema.raw(`
+      ALTER TABLE recruitment_contacts
+      ADD CONSTRAINT recruitment_contacts_status_check
+      CHECK (
+        status IN (
+          'not_yet_contacted',
+          'awaiting_response',
+          'to_follow_up',
+          'not_available',
+          'pending_validation',
+          'cancelled',
+          'recruited'
+        )
+      )
+    `)
+  }
+}


### PR DESCRIPTION
Correction d'un problème de persistance des statuts de recrutement personnalisés après actualisation.

La cause principale était une contrainte PostgreSQL sur la propriété recruitment_contacts.status qui n'autorisait que les statuts prédéfinis. J'ai ajouté une migration supprimant cette contrainte et mis à jour le typage du backend afin que les statuts personnalisés soient désormais pleinement pris en charge.

Avant de tester, vous devrez exécuter la commande suivante :

node ace migration:run

Tests effectués :

Création de statuts personnalisés

Attribution de ces statuts aux contacts

Actualisation de la page

Basculement entre les statuts par défaut et les statuts personnalisés