### PR TITLE
fix: look up callsheet by id instead of project_id in getOne

### DIFF
--- a/app/controllers/callsheets_controller.ts
+++ b/app/controllers/callsheets_controller.ts
@@ -29,6 +29,9 @@ export default class CallsheetsController {
               folderQuery.preload('files')
             })
             pieceQuery.preload('files')
+            pieceQuery.preload('selectedMaterial', (materialQuery) => {
+              materialQuery.preload('files')
+            })
           })
           .preload('sectionGroup', (sectionGroupQuery) => {
             sectionGroupQuery.preload('sections', (sectionQuery) => {

--- a/app/controllers/callsheets_controller.ts
+++ b/app/controllers/callsheets_controller.ts
@@ -15,7 +15,7 @@ export default class CallsheetsController {
     const { params } = await ctx.request.validateUsing(getCallsheetValidator)
 
     const callsheet = await Callsheet.query()
-      .where('project_id', params.id)
+      .where('id', params.id)
       .orderBy('updated_at', 'desc')
       .preload('contents')
       .preload('project', (projectQuery) => {


### PR DESCRIPTION
Fixes #167

1. The getOne method in callsheets_controller.ts was querying 
the database using .where('project_id', params.id) but the 
route /call_sheets/:id/:visitorId passes the callsheet ID, 
not the project ID. This caused the public callsheet page 
to get stuck on "Loading..." indefinitely.

Changed .where('project_id', params.id) to .where('id', params.id).


2. Added preload of selectedMaterial with its files on pieces. 
   Scores were not available on the public callsheet page because 
   the frontend was calling authenticated API routes that don't 
   work without login.