### PR TITLE
fix: return 404 instead of loading indefinitely when callsheet is not found

### DIFF
--- a/app/controllers/callsheets_controller.ts
+++ b/app/controllers/callsheets_controller.ts
@@ -40,9 +40,9 @@ export default class CallsheetsController {
           })
           .preload('registration')
       })
-      .firstOrFail()
+      .first()
 
-    if (!callsheet) return ctx.response.notFound()
+    if (!callsheet) return ctx.response.notFound({ message: 'Callsheet not found' })
 
     if (params.visitorId) {
       const contact = await Contact.find(params.visitorId)


### PR DESCRIPTION
Bug found during testing of issue #99.

When opening a public callsheet URL with an invalid callsheet ID, 
the page was stuck on "Loading..." indefinitely instead of showing 
a proper error.

Changed .firstOrFail() to .first() in the getOne method and added 
an explicit 404 response when no callsheet is found.