### PR TITLE
Fix instruments not saved at contact creation (#184)

### DIFF
--- a/app/controllers/contacts_controller.ts
+++ b/app/controllers/contacts_controller.ts
@@ -137,11 +137,12 @@ export default class ContactsController {
 
     const data = await ctx.request.validateUsing(createContactValidator)
 
+    let contact
     if (!data.id) {
-      return await Contact.create({ ...data, validated: true })
+      contact = await Contact.create({ ...data, validated: true })
+    } else {
+      contact = await Contact.updateOrCreate({ id: data.id }, { ...data, validated: true })
     }
-
-    const contact = await Contact.updateOrCreate({ id: data.id }, { ...data, validated: true })
 
     if (data.instruments) {
       let toSync = Object.assign(


### PR DESCRIPTION
Fixes #184

The bug: when creating a new contact with an instrument, the instrument was discarded. It only worked when adding it later via "modify" on an existing contact.

Cause: in createOrUpdate, the creation case did a "return" right away, so the code that syncs the instruments was never reached for new contacts.

Fix: store the created contact in a variable instead of returning immediately, so both creation and update go through the instruments sync.

Tested locally: created a new contact with an instrument, it's now saved correctly.