### PR TITLE
feat(contents): add show_on_registration column and validation

### DIFF
--- a/app/models/content_callsheet.ts
+++ b/app/models/content_callsheet.ts
@@ -35,4 +35,7 @@ export default class ContentCallsheet extends BaseModel {
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
+
+  @column()
+  declare showOnRegistration: boolean
 }

--- a/app/models/content_registration.ts
+++ b/app/models/content_registration.ts
@@ -30,4 +30,7 @@ export default class ContentRegistration extends BaseModel {
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
+
+  @column()
+  declare showOnRegistration: boolean
 }

--- a/app/validators/callsheet.ts
+++ b/app/validators/callsheet.ts
@@ -12,6 +12,7 @@ export const createCallsheetValidator = vine.compile(
         text: vine.string(),
         order: vine.number().optional(),
         position: vine.enum(['above', 'below']).optional(),
+        showOnRegistration: vine.boolean().optional()
       })
     ),
   })

--- a/app/validators/registration.ts
+++ b/app/validators/registration.ts
@@ -8,6 +8,7 @@ export const createRegistrationValidator = vine.compile(
         text: vine.string(),
         order: vine.number().optional(),
         position: vine.enum(['above', 'below']).optional(),
+        showOnRegistration: vine.boolean().optional()
       })
     ),
     form: vine.array(

--- a/database/migrations/1785140928929_create_add_show_on_registration_to_contents_table.ts
+++ b/database/migrations/1785140928929_create_add_show_on_registration_to_contents_table.ts
@@ -1,0 +1,34 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+export default class AddShowOnRegistrationToContents extends BaseSchema {
+
+  protected tableRegistration = 'content_registrations'
+  protected tableCallsheet = 'content_callsheets'
+
+  public async up () {
+    // Vérifie et ajoute pour la première table
+    const hasRegistrationCol = await this.schema.hasColumn(this.tableRegistration, 'show_on_registration')
+    if (!hasRegistrationCol) {
+      this.schema.alterTable(this.tableRegistration, (table) => {
+        table.boolean('show_on_registration').defaultTo(false)
+      })
+    }
+
+    // Vérifie et ajoute pour la deuxième table
+    const hasCallsheetCol = await this.schema.hasColumn(this.tableCallsheet, 'show_on_registration')
+    if (!hasCallsheetCol) {
+      this.schema.alterTable(this.tableCallsheet, (table) => {
+        table.boolean('show_on_registration').defaultTo(false)
+      })
+    }
+  }
+
+  public async down () {
+    this.schema.alterTable(this.tableRegistration, (table) => {
+      table.dropColumn('show_on_registration')
+    })
+
+    this.schema.alterTable(this.tableCallsheet, (table) => {
+      table.dropColumn('show_on_registration')
+    })
+  }
+}


### PR DESCRIPTION
Cette PR est la compagne de la PR front (feat/registration-block-visibility-84).

Migration : Ajout de la colonne show_on_registration (booléen, défaut false) sur les tables content_callsheets et content_registrations.

Modèles : Déclaration de la colonne dans les modèles Lucid (ContentCallsheet et ContentRegistration).

Validation : Ajout du champ optionnel dans les validateurs VineJS.