### PR TITLE
fix: restore POST /mailing route for sendUnique (removed in #66)

### DIFF
--- a/start/routes.ts
+++ b/start/routes.ts
@@ -638,6 +638,7 @@ router.get(
       // =============================================================================
       router
         .group(() => {
+          router.post('/', [MailingsController, 'sendUnique'])
           router.post('/sendRefusalEmailToParticipant', [
             MailingsController,
             'sendRefusalEmailToParticipant',


### PR DESCRIPTION
The POST /mailing route (MailingsController.sendUnique) was accidentally
removed in commit 1ba034d (auditions feature, #66).

As a result, sending a unique email to a list from the Mailing page returns
a 404 and no email is sent, while the frontend still shows "Email sent".

This restores the route in the current /mailing group.

Tested locally with Mailpit: the email is now correctly sent and received.