### PR TITLE
Fix management call sheet lookup and add contact API tests

### DIFF
--- a/app/controllers/callsheets_controller.ts
+++ b/app/controllers/callsheets_controller.ts
@@ -13,9 +13,10 @@ export default class CallsheetsController {
 
   async getOne(ctx: HttpContext) {
     const { params } = await ctx.request.validateUsing(getCallsheetValidator)
+    const callsheetId = params.callsheetId ?? params.id
 
     const callsheet = await Callsheet.query()
-      .where('id', params.id)
+      .where('id', callsheetId)
       .orderBy('updated_at', 'desc')
       .preload('contents')
       .preload('project', (projectQuery) => {

--- a/app/controllers/contacts_controller.ts
+++ b/app/controllers/contacts_controller.ts
@@ -1,4 +1,3 @@
-
 import Contact from '#models/contact'
 import RecruitmentContact from '#models/recruitment_contact'
 import { simpleFilter, advancedFilter } from 'adonisjs-filters'
@@ -219,19 +218,20 @@ export default class ContactsController {
       .if(organizationId, (query) => query.where('organization_id', organizationId!))
       .first()
 
-    if (contact) {
-      let participations = await contact.related('participants').query()
-
-      for (let participation of participations) {
-        await participation.related('answers').query().delete()
-        await participation.related('rehearsals').query().delete()
-        await participation.delete()
-      }
-
-      await contact.delete()
-      return response.send('contact deleted')
+    if (!contact) {
+      return response.status(404).send('contact not found')
     }
-    return response.send('contact not found')
+
+    let participations = await contact.related('participants').query()
+
+    for (let participation of participations) {
+      await participation.related('answers').query().delete()
+      await participation.related('rehearsals').query().delete()
+      await participation.delete()
+    }
+
+    await contact.delete()
+    return response.send('contact deleted')
   }
 
   async create(ctx: HttpContext) {

--- a/app/validators/callsheet.ts
+++ b/app/validators/callsheet.ts
@@ -21,6 +21,7 @@ export const getCallsheetValidator = vine.compile(
   vine.object({
     params: vine.object({
       visitorId: vine.number().optional(),
+      callsheetId: vine.number().optional(),
       id: vine.number(),
     }),
   })

--- a/tests/functional/callsheet.spec.ts
+++ b/tests/functional/callsheet.spec.ts
@@ -1,11 +1,12 @@
 import { test } from '@japa/runner'
 import Project from '#models/project'
+import env from '#start/env'
 
 test.group('Callsheet API', (group) => {
   async function getToken(client: any) {
     const response = await client.post('/sign_in').json({
-      email: 'admin@admin.admin',
-      password: 'admin',
+      email: env.get('ADMIN_EMAIL'),
+      password: env.get('ADMIN_PASSWORD'),
     })
     return response.body().token
   }

--- a/tests/functional/callsheet.spec.ts
+++ b/tests/functional/callsheet.spec.ts
@@ -1,19 +1,29 @@
 import { test } from '@japa/runner'
+import Project from '#models/project'
 
-test.group('Callsheet API', () => {
+test.group('Callsheet API', (group) => {
   async function getToken(client: any) {
     const response = await client.post('/sign_in').json({
       email: 'admin@admin.admin',
-      password: 'admin'
+      password: 'admin',
     })
     return response.body().token
   }
 
+  let testProjectId: number
+
+  group.setup(async () => {
+    const project = await Project.create({ name: 'Callsheet Test Project' })
+    testProjectId = project.id
+  })
+
+  group.teardown(async () => {
+    await Project.query().where('id', testProjectId).delete()
+  })
+
   test('should return empty array for non-existent project', async ({ client }) => {
     const token = await getToken(client)
-    const response = await client
-      .get('/projects/99999/management/call_sheets')
-      .bearerToken(token)
+    const response = await client.get('/projects/99999/management/call_sheets').bearerToken(token)
     response.assertStatus(200)
   })
 
@@ -30,7 +40,7 @@ test.group('Callsheet API', () => {
       .json({
         project_id: 1,
         version: '',
-        contents: [{ title: 'Test block', text: 'Test content' }]
+        contents: [{ title: 'Test block', text: 'Test content' }],
       })
     response.assertStatus(422)
   })
@@ -51,5 +61,81 @@ test.group('Callsheet API', () => {
   test('should return 401 for unauthenticated access', async ({ client }) => {
     const response = await client.get('/projects/99999/management/call_sheets')
     response.assertStatus(401)
+  })
+
+  test('should return the correct callsheet via the management route', async ({ client }) => {
+    const token = await getToken(client)
+
+    const createResponse = await client
+      .post(`/projects/${testProjectId}/management/call_sheets`)
+      .bearerToken(token)
+      .json({
+        project_id: testProjectId,
+        version: 'regression-test',
+        contents: [{ title: 'Regression block', text: 'Regression content' }],
+      })
+    const callsheetId = createResponse.body()[0].callsheetId
+
+    const getResponse = await client
+      .get(`/projects/${testProjectId}/management/call_sheets/${callsheetId}`)
+      .bearerToken(token)
+    getResponse.assertStatus(200)
+    getResponse.assertBodyContains({ id: callsheetId })
+
+    await client
+      .delete(`/projects/${testProjectId}/management/call_sheets/${callsheetId}`)
+      .bearerToken(token)
+  })
+
+  test('should create a callsheet with valid data', async ({ client }) => {
+    const token = await getToken(client)
+
+    const response = await client
+      .post(`/projects/${testProjectId}/management/call_sheets`)
+      .bearerToken(token)
+      .json({
+        project_id: testProjectId,
+        version: 'create-test',
+        contents: [{ title: 'Create block', text: 'Create content' }],
+      })
+    response.assertStatus(200)
+    response.assertBodyContains([{ title: 'Create block', text: 'Create content' }])
+
+    const callsheetId = response.body()[0].callsheetId
+    await client
+      .delete(`/projects/${testProjectId}/management/call_sheets/${callsheetId}`)
+      .bearerToken(token)
+  })
+
+  test('should delete an existing callsheet', async ({ client }) => {
+    const token = await getToken(client)
+
+    const createResponse = await client
+      .post(`/projects/${testProjectId}/management/call_sheets`)
+      .bearerToken(token)
+      .json({
+        project_id: testProjectId,
+        version: 'delete-test',
+        contents: [{ title: 'Delete block', text: 'Delete content' }],
+      })
+    const callsheetId = createResponse.body()[0].callsheetId
+
+    const deleteResponse = await client
+      .delete(`/projects/${testProjectId}/management/call_sheets/${callsheetId}`)
+      .bearerToken(token)
+    deleteResponse.assertStatus(204)
+
+    const getResponse = await client
+      .get(`/projects/${testProjectId}/management/call_sheets/${callsheetId}`)
+      .bearerToken(token)
+    getResponse.assertStatus(404)
+  })
+
+  test('should return 404 for invalid callsheet ID on the management route', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .get(`/projects/${testProjectId}/management/call_sheets/99999`)
+      .bearerToken(token)
+    response.assertStatus(404)
   })
 })

--- a/tests/functional/contact.spec.ts
+++ b/tests/functional/contact.spec.ts
@@ -1,0 +1,66 @@
+import { test } from '@japa/runner'
+
+test.group('Contact API', () => {
+  async function getToken(client: any) {
+    const response = await client.post('/sign_in').json({
+      email: 'admin@admin.admin',
+      password: 'admin'
+    })
+    return response.body().token
+  }
+
+  test('should return 200 for authenticated user', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .get('/contact')
+      .bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  test('should return 404 for invalid contact ID', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .get('/contact/99999')
+      .bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  test('should fail when required fields are missing', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .put('/contact')
+      .bearerToken(token)
+      .json({})
+    response.assertStatus(422)
+  })
+
+  test('should return 200 for getValidation', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .get('/contact/validation')
+      .bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  test('should fail to merge contacts when required fields are missing', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .post('/contact/validation/merge')
+      .bearerToken(token)
+      .json({})
+    response.assertStatus(422)
+  })
+
+  test('should return 200 when deleting non-existent contact', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .delete('/contact/99999')
+      .bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  test('should return 401 for unauthenticated access', async ({ client }) => {
+    const response = await client.get('/contact')
+    response.assertStatus(401)
+  })
+})

--- a/tests/functional/contact.spec.ts
+++ b/tests/functional/contact.spec.ts
@@ -1,62 +1,49 @@
 import { test } from '@japa/runner'
+import env from '#start/env'
 
 test.group('Contact API', () => {
   async function getToken(client: any) {
     const response = await client.post('/sign_in').json({
-      email: 'admin@admin.admin',
-      password: 'admin'
+      email: env.get('ADMIN_EMAIL'),
+      password: env.get('ADMIN_PASSWORD'),
     })
     return response.body().token
   }
 
   test('should return 200 for authenticated user', async ({ client }) => {
     const token = await getToken(client)
-    const response = await client
-      .get('/contact')
-      .bearerToken(token)
+    const response = await client.get('/contact').bearerToken(token)
     response.assertStatus(200)
   })
 
   test('should return 404 for invalid contact ID', async ({ client }) => {
     const token = await getToken(client)
-    const response = await client
-      .get('/contact/99999')
-      .bearerToken(token)
+    const response = await client.get('/contact/99999').bearerToken(token)
     response.assertStatus(404)
   })
 
   test('should fail when required fields are missing', async ({ client }) => {
     const token = await getToken(client)
-    const response = await client
-      .put('/contact')
-      .bearerToken(token)
-      .json({})
+    const response = await client.put('/contact').bearerToken(token).json({})
     response.assertStatus(422)
   })
 
   test('should return 200 for getValidation', async ({ client }) => {
     const token = await getToken(client)
-    const response = await client
-      .get('/contact/validation')
-      .bearerToken(token)
+    const response = await client.get('/contact/validation').bearerToken(token)
     response.assertStatus(200)
   })
 
   test('should fail to merge contacts when required fields are missing', async ({ client }) => {
     const token = await getToken(client)
-    const response = await client
-      .post('/contact/validation/merge')
-      .bearerToken(token)
-      .json({})
+    const response = await client.post('/contact/validation/merge').bearerToken(token).json({})
     response.assertStatus(422)
   })
 
-  test('should return 200 when deleting non-existent contact', async ({ client }) => {
+  test('should return 404 when deleting non-existent contact', async ({ client }) => {
     const token = await getToken(client)
-    const response = await client
-      .delete('/contact/99999')
-      .bearerToken(token)
-    response.assertStatus(200)
+    const response = await client.delete('/contact/99999').bearerToken(token)
+    response.assertStatus(404)
   })
 
   test('should return 401 for unauthenticated access', async ({ client }) => {

--- a/tests/functional/project.spec.ts
+++ b/tests/functional/project.spec.ts
@@ -1,10 +1,11 @@
 import { test } from '@japa/runner'
+import env from '#start/env'
 
 test.group('Project API', () => {
   async function getToken(client: any) {
     const response = await client.post('/sign_in').json({
-      email: 'admin@admin.admin',
-      password: 'admin',
+      email: env.get('ADMIN_EMAIL'),
+      password: env.get('ADMIN_PASSWORD'),
     })
     return response.body().token
   }

--- a/tests/functional/project.spec.ts
+++ b/tests/functional/project.spec.ts
@@ -1,0 +1,52 @@
+import { test } from '@japa/runner'
+
+test.group('Project API', () => {
+  async function getToken(client: any) {
+    const response = await client.post('/sign_in').json({
+      email: 'admin@admin.admin',
+      password: 'admin',
+    })
+    return response.body().token
+  }
+
+  test('should return 200 for authenticated user', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.get('/projects').bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  test('should return 404 for invalid project ID', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.get('/projects/99999').bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  test('should fail when required fields are missing', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.post('/projects').bearerToken(token).json({})
+    response.assertStatus(422)
+  })
+
+  test('should return 200 when deleting non-existent project', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.delete('/projects/99999').bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  test('should return 404 for management dashboard of invalid project', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.get('/projects/99999/management').bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  test('should return 404 for attendance of invalid project', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.get('/projects/99999/management/attendance').bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  test('should return 401 for unauthenticated access', async ({ client }) => {
+    const response = await client.get('/projects')
+    response.assertStatus(401)
+  })
+})


### PR DESCRIPTION
 "Fixes getOne querying by project ID instead of callsheet ID on the management call sheet route. Adds missing tests/functional/contact.spec.ts."