### PR TITLE
feat: add Japa automated tests for users and recruitment API

### DIFF
--- a/tests/functional/recruitment.spec.ts
+++ b/tests/functional/recruitment.spec.ts
@@ -1,0 +1,62 @@
+import { test } from '@japa/runner'
+
+test.group('Recruitment API', () => {
+  async function getToken(client: any) {
+    const response = await client.post('/sign_in').json({
+      email: 'admin@admin.admin',
+      password: 'admin'
+    })
+    return response.body().token
+  }
+
+  // Test 1: Unauthenticated access returns 401
+  test('should return 401 for unauthenticated access', async ({ client }) => {
+    const response = await client.get('/projects/1/management/recruitment/settings')
+    response.assertStatus(401)
+  })
+
+  // Test 2: Get settings for non-existent project returns 404
+  test('should return 404 for non-existent project settings', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .get('/projects/99999/management/recruitment/settings')
+      .bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  // Test 3: Get contacts for non-existent project returns 200 with empty data
+  test('should return 200 for recruitment contacts on non-existent project', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .get('/projects/99999/management/recruitment/contacts')
+      .bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  // Test 4: Get stats for non-existent project
+  test('should return stats for non-existent project', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .get('/projects/99999/management/recruitment/stats')
+      .bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  // Test 5: Get available projects returns 200
+  test('should return available projects for authenticated user', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .get('/projects/99999/management/recruitment/import-project')
+      .bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  // Test 6: Delete non-existent recruitment contact returns 404
+  test('should return 404 when deleting non-existent recruitment contact', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .delete('/projects/99999/management/recruitment/contacts/99999')
+      .bearerToken(token)
+    response.assertStatus(404)
+  })
+})

--- a/tests/functional/users.spec.ts
+++ b/tests/functional/users.spec.ts
@@ -1,0 +1,69 @@
+import { test } from '@japa/runner'
+
+test.group('Users API', () => {
+  async function getToken(client: any) {
+    const response = await client.post('/sign_in').json({
+      email: 'admin@admin.admin',
+      password: 'admin'
+    })
+    return response.body().token
+  }
+
+  // Test 1: Unauthenticated access returns 401
+  test('should return 401 for unauthenticated access', async ({ client }) => {
+    const response = await client.get('/users')
+    response.assertStatus(401)
+  })
+
+  // Test 2: Get all users returns 200 for authenticated user
+  test('should return 200 for authenticated user', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .get('/users')
+      .bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  // Test 3: Get current user returns 200
+  test('should return current user for authenticated user', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .get('/users/current')
+      .bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  // Test 4: Create user with missing fields returns 422
+  test('should fail when required fields are missing', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .put('/users')
+      .bearerToken(token)
+      .json({})
+    response.assertStatus(422)
+  })
+
+  // Test 5: Create user with valid data
+  test('should create a user with valid data', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .put('/users')
+      .bearerToken(token)
+      .json({
+        email: 'testuser@test.com',
+        password: 'password123',
+        password_confirmation: 'password123',
+        fullName: 'Test User'
+      })
+    response.assertStatus(200)
+  })
+
+  // Test 6: Delete a non-existent user
+  test('should handle deleting non-existent user', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .delete('/users/99999')
+      .bearerToken(token)
+    response.assertStatus(200)
+  })
+})

--- a/tests/functional/users.spec.ts
+++ b/tests/functional/users.spec.ts
@@ -50,7 +50,7 @@ test.group('Users API', () => {
       .put('/users')
       .bearerToken(token)
       .json({
-        email: 'testuser@test.com',
+        email: `testuser${Date.now()}@test.com`,
         password: 'password123',
         password_confirmation: 'password123',
         fullName: 'Test User'


### PR DESCRIPTION
Adds automated backend tests for users and recruitment features using Japa.

Users tests (6):
- Returns 401 for unauthenticated access
- Returns 200 for authenticated user
- Returns current user for authenticated user
- Fails when required fields are missing
- Creates a user with valid data
- Handles deleting non-existent user

Recruitment tests (6):
- Returns 401 for unauthenticated access
- Returns 404 for non-existent project settings
- Returns 200 for recruitment contacts on non-existent project
- Returns stats for non-existent project
- Returns available projects for authenticated user
- Returns 404 when deleting non-existent recruitment contact

25 tests total across all test files, all passing.