### PR TITLE
feat: add Japa automated tests for composers, pieces and lists API

### DIFF
--- a/tests/functional/composers.spec.ts
+++ b/tests/functional/composers.spec.ts
@@ -1,0 +1,50 @@
+import { test } from '@japa/runner'
+
+test.group('Composers API', () => {
+  async function getToken(client: any) {
+    const response = await client.post('/sign_in').json({
+      email: 'admin@admin.admin',
+      password: 'admin'
+    })
+    return response.body().token
+  }
+
+  test('should return 401 for unauthenticated access', async ({ client }) => {
+    const response = await client.get('/composer')
+    response.assertStatus(401)
+  })
+
+  test('should return 200 for authenticated user', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.get('/composer').bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  test('should return 404 for invalid composer pieces ID', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.get('/composer/99999/pieces').bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  test('should create a composer with valid data', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .put('/composer')
+      .bearerToken(token)
+      .json({
+        short_name: `TestComp${Date.now()}`,
+        long_name: 'Test Composer',
+        birth_date: -5364662400000,
+        death_date: -3786825600000,
+        country: 'France',
+        main_style: 'Classical'
+      })
+    response.assertStatus(200)
+  })
+
+  test('should return 404 when deleting non-existent composer', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.delete('/composer/99999').bearerToken(token)
+    response.assertStatus(404)
+  })
+})

--- a/tests/functional/lists.spec.ts
+++ b/tests/functional/lists.spec.ts
@@ -1,0 +1,55 @@
+import { test } from '@japa/runner'
+
+test.group('Lists API', () => {
+  async function getToken(client: any) {
+    const response = await client.post('/sign_in').json({
+      email: 'admin@admin.admin',
+      password: 'admin'
+    })
+    return response.body().token
+  }
+
+  test('should return 401 for unauthenticated access', async ({ client }) => {
+    const response = await client.get('/lists')
+    response.assertStatus(401)
+  })
+
+  test('should return 200 for authenticated user', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.get('/lists').bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  test('should return 404 for invalid list ID', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.get('/lists/99999').bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  test('should fail when required fields are missing', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .put('/lists')
+      .bearerToken(token)
+      .json({})
+    response.assertStatus(422)
+  })
+
+  test('should create a list with valid data', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .put('/lists')
+      .bearerToken(token)
+      .json({
+        name: `Test List ${Date.now()}`,
+        contacts: []
+      })
+    response.assertStatus(200)
+  })
+
+  test('should return 404 when deleting non-existent list', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.delete('/lists/99999').bearerToken(token)
+    response.assertStatus(404)
+  })
+})

--- a/tests/functional/pieces.spec.ts
+++ b/tests/functional/pieces.spec.ts
@@ -1,0 +1,37 @@
+import { test } from '@japa/runner'
+
+test.group('Pieces API', () => {
+  async function getToken(client: any) {
+    const response = await client.post('/sign_in').json({
+      email: 'admin@admin.admin',
+      password: 'admin'
+    })
+    return response.body().token
+  }
+
+  test('should return 401 for unauthenticated access', async ({ client }) => {
+    const response = await client.get('/piece')
+    response.assertStatus(401)
+  })
+
+  test('should return 200 for authenticated user', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.get('/piece').bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  test('should fail when required fields are missing', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client
+      .put('/piece')
+      .bearerToken(token)
+      .json({})
+    response.assertStatus(422)
+  })
+
+  test('should return 200 when deleting non-existent piece', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.delete('/piece/99999').bearerToken(token)
+    response.assertStatus(200)
+  })
+})


### PR DESCRIPTION
Adds automated backend tests for composers, pieces and lists features using Japa.

Composers tests (5):
- Returns 401 for unauthenticated access
- Returns 200 for authenticated user
- Returns 404 for invalid composer pieces ID
- Creates a composer with valid data
- Returns 404 when deleting non-existent composer

Pieces tests (4):
- Returns 401 for unauthenticated access
- Returns 200 for authenticated user
- Fails when required fields are missing
- Returns 200 when deleting non-existent piece

Lists tests (6):
- Returns 401 for unauthenticated access
- Returns 200 for authenticated user
- Returns 404 for invalid list ID
- Fails when required fields are missing
- Creates a list with valid data
- Returns 404 when deleting non-existent list

28 tests total across all test files, all passing.