### PR TITLE
feat: add Japa automated tests for files API

### DIFF
--- a/app/controllers/files_controller.ts
+++ b/app/controllers/files_controller.ts
@@ -104,7 +104,14 @@ export default class FilesController {
       const file = await File.query()
         .where('id', ctx.params.id)
         .if(organizationId, (query) => query.where('organization_id', organizationId!))
-        .firstOrFail()
+        .first()
+
+      if (!file) {
+        return ctx.response.status(404).json({
+          error: 'File not found',
+          fileId: ctx.params.id,
+        })
+      }
 
       console.log(`📥 Download request for file: ${file.name} (ID: ${ctx.params.id})`)
       console.log(`📁 File path: ${file.path}`)
@@ -167,7 +174,14 @@ export default class FilesController {
       const file = await File.query()
         .where('id', params.id)
         .if(organizationId, (query) => query.where('organization_id', organizationId!))
-        .firstOrFail()
+        .first()
+
+      if (!file) {
+        return response.status(404).json({
+          error: 'File not found',
+          fileId: params.id,
+        })
+      }
 
       const filePath = file.path
 

--- a/tests/functional/files.spec.ts
+++ b/tests/functional/files.spec.ts
@@ -1,0 +1,63 @@
+import { test } from '@japa/runner'
+
+test.group('Files API', () => {
+  async function getToken(client: any) {
+    const response = await client.post('/sign_in').json({
+      email: 'admin@admin.admin',
+      password: 'admin',
+    })
+    return response.body().token
+  }
+
+  test('should return 200 for authenticated user', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.get('/files').bearerToken(token)
+    response.assertStatus(200)
+  })
+
+  test('should return 401 for unauthenticated access', async ({ client }) => {
+    const response = await client.get('/files')
+    response.assertStatus(401)
+  })
+
+  test('should fail to upload when no file is provided', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.post('/files').bearerToken(token)
+    response.assertStatus(422)
+  })
+
+  test('should return 404 when updating a non-existent file', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.put('/files/99999').bearerToken(token).json({})
+    response.assertStatus(404)
+  })
+
+  test('should return 404 when deleting a non-existent file', async ({ client }) => {
+    const token = await getToken(client)
+    const response = await client.delete('/files/99999').bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  test('should return 404 for info on a non-existent file (protected route)', async ({
+    client,
+  }) => {
+    const token = await getToken(client)
+    const response = await client.get('/files/99999/info').bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  test('should return 404 for the public info route on a non-existent file', async ({ client }) => {
+    const response = await client.get('/files/info/99999')
+    response.assertStatus(404)
+  })
+
+  test('should return 404 for downloading a non-existent file', async ({ client }) => {
+    const response = await client.get('/files/download/99999')
+    response.assertStatus(404)
+  })
+
+  test('should return 404 for streaming a non-existent file', async ({ client }) => {
+    const response = await client.get('/files/stream/99999')
+    response.assertStatus(404)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds functional tests for the /files API (getAll, upload validation, update/delete/info 404s, public info/download/stream routes)
- Fixes FilesController.download and .stream returning 500 instead of 404 when the requested file does not exist, matching the pattern already used in .info

## Test plan
- [x] node ace test functional --files files (9 tests passing locally)